### PR TITLE
Feature: Dark Mode (closes #7)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,18 @@ import Study from './pages/Study'
 import Practice from './pages/Practice'
 import Settings from './pages/Settings'
 import { useSettings } from './context/SettingsContext'
+import { useEffect } from 'react'
 
 function App() {
   const { settings, FONT_SIZES } = useSettings()
   const fontSize = FONT_SIZES[settings.fontSize] || '16px'
+
+  useEffect(() => {
+    document.documentElement.setAttribute(
+      'data-theme',
+      settings.darkMode ? 'dark' : 'light'
+    )
+  }, [settings.darkMode])
 
   return (
     <div style={{ fontSize }}>

--- a/src/components/Exam.css
+++ b/src/components/Exam.css
@@ -20,19 +20,19 @@
 .back-link {
   background: none;
   border: none;
-  color: #666;
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 0.9rem;
   padding: 0.5rem;
 }
 
 .back-link:hover {
-  color: #333;
+  color: var(--text-primary);
 }
 
 .question-counter {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--text-secondary);
   font-weight: 500;
 }
 
@@ -48,16 +48,17 @@
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
   font-weight: 600;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--border-color);
   border-radius: 8px;
-  background: white;
+  background: var(--card-bg);
+  color: var(--text-primary);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .nav-button:hover:not(:disabled) {
-  border-color: #4a90d9;
-  color: #4a90d9;
+  border-color: var(--button-primary);
+  color: var(--button-primary);
 }
 
 .nav-button:disabled {
@@ -66,14 +67,14 @@
 }
 
 .nav-button.next-button {
-  background-color: #4a90d9;
-  border-color: #4a90d9;
+  background-color: var(--button-primary);
+  border-color: var(--button-primary);
   color: white;
 }
 
 .nav-button.next-button:hover:not(:disabled) {
-  background-color: #357abd;
-  border-color: #357abd;
+  background-color: var(--button-hover);
+  border-color: var(--button-hover);
   color: white;
 }
 
@@ -83,5 +84,5 @@
   align-items: center;
   min-height: 300px;
   font-size: 1.2rem;
-  color: #666;
+  color: var(--text-secondary);
 }

--- a/src/components/ExamResults.css
+++ b/src/components/ExamResults.css
@@ -3,16 +3,17 @@
   flex-direction: column;
   align-items: center;
   padding: 2rem;
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
   max-width: 700px;
   width: 100%;
+  transition: background-color 0.3s ease;
 }
 
 .exam-results h2 {
   font-size: 2rem;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 2rem;
 }
 
@@ -24,7 +25,7 @@
 .score-percentage {
   font-size: 4rem;
   font-weight: 700;
-  color: #4a90d9;
+  color: var(--button-primary);
   line-height: 1;
 }
 
@@ -37,11 +38,11 @@
 }
 
 .correct-count {
-  color: #28a745;
+  color: var(--correct-text);
 }
 
 .wrong-count {
-  color: #dc3545;
+  color: var(--incorrect-text);
 }
 
 .result-message {
@@ -50,20 +51,20 @@
 }
 
 .pass-message {
-  color: #28a745;
+  color: var(--correct-text);
 }
 
 .fail-message {
-  color: #dc3545;
+  color: var(--incorrect-text);
 }
 
 .view-incorrect-button {
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
   font-weight: 600;
-  color: #dc3545;
-  background-color: white;
-  border: 2px solid #dc3545;
+  color: var(--incorrect-text);
+  background-color: var(--card-bg);
+  border: 2px solid var(--incorrect-text);
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s;
@@ -71,7 +72,7 @@
 }
 
 .view-incorrect-button:hover {
-  background-color: #dc3545;
+  background-color: var(--incorrect-text);
   color: white;
 }
 
@@ -83,8 +84,8 @@
 }
 
 .incorrect-item {
-  background: #fff5f5;
-  border: 1px solid #ffcccc;
+  background: var(--incorrect-bg);
+  border: 1px solid var(--incorrect-text);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
@@ -92,13 +93,13 @@
 
 .incorrect-question {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 0.75rem;
   line-height: 1.4;
 }
 
 .question-number {
-  color: #dc3545;
+  color: var(--incorrect-text);
   font-weight: 700;
 }
 
@@ -116,19 +117,19 @@
 }
 
 .your-answer {
-  background: #ffebee;
-  border-left: 3px solid #dc3545;
+  background: var(--incorrect-bg);
+  border-left: 3px solid var(--incorrect-text);
 }
 
 .correct-answer {
-  background: #e8f5e9;
-  border-left: 3px solid #28a745;
+  background: var(--correct-bg);
+  border-left: 3px solid var(--correct-text);
 }
 
 .answer-label {
   font-weight: 600;
   margin-right: 0.5rem;
-  color: #555;
+  color: var(--text-secondary);
 }
 
 .result-buttons {
@@ -137,7 +138,7 @@
 }
 
 .restart-button,
-.home-button {
+.home-button-results {
   padding: 0.875rem 1.5rem;
   font-size: 1rem;
   font-weight: 600;
@@ -149,19 +150,19 @@
 }
 
 .restart-button {
-  background-color: #4a90d9;
+  background-color: var(--button-primary);
   color: white;
 }
 
 .restart-button:hover {
-  background-color: #357abd;
+  background-color: var(--button-hover);
 }
 
-.home-button {
+.home-button-results {
   background-color: #6c757d;
   color: white;
 }
 
-.home-button:hover {
+.home-button-results:hover {
   background-color: #5a6268;
 }

--- a/src/components/LicenseSelector.css
+++ b/src/components/LicenseSelector.css
@@ -8,7 +8,7 @@
 .license-selector h2 {
   margin-bottom: 2rem;
   font-size: 1.5rem;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .license-buttons {
@@ -24,15 +24,15 @@
   flex-direction: column;
   align-items: center;
   padding: 1.25rem 2rem;
-  border: 2px solid #4a90d9;
+  border: 2px solid var(--button-primary);
   border-radius: 8px;
-  background-color: white;
+  background-color: var(--card-bg);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .license-button:hover {
-  background-color: #4a90d9;
+  background-color: var(--button-primary);
 }
 
 .license-button:hover .license-name,
@@ -43,11 +43,11 @@
 .license-name {
   font-size: 1.25rem;
   font-weight: 600;
-  color: #4a90d9;
+  color: var(--button-primary);
 }
 
 .license-description {
   font-size: 0.875rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-top: 0.25rem;
 }

--- a/src/components/QuestionCard.css
+++ b/src/components/QuestionCard.css
@@ -1,10 +1,11 @@
 .question-card {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
   max-width: 700px;
   width: 100%;
+  transition: background-color 0.3s ease;
 }
 
 .question-header {
@@ -16,19 +17,19 @@
 
 .question-id {
   font-weight: 600;
-  color: #4a90d9;
+  color: var(--button-primary);
 }
 
 .question-refs {
   font-size: 0.875rem;
-  color: #888;
+  color: var(--text-secondary);
   flex: 1;
   text-align: right;
   margin-right: 0.5rem;
 }
 
 .tts-button {
-  background: #f0f0f0;
+  background: var(--bg-primary);
   border: none;
   border-radius: 50%;
   width: 36px;
@@ -42,7 +43,7 @@
 }
 
 .tts-button:hover {
-  background: #e0e0e0;
+  background: var(--border-color);
   transform: scale(1.1);
 }
 
@@ -53,12 +54,12 @@
 }
 
 .tts-button.reading {
-  background: #4a90d9;
+  background: var(--button-primary);
   color: white;
 }
 
 .mic-button {
-  background: #f0f0f0;
+  background: var(--bg-primary);
   border: none;
   border-radius: 50%;
   width: 36px;
@@ -72,7 +73,7 @@
 }
 
 .mic-button:hover {
-  background: #e0e0e0;
+  background: var(--border-color);
   transform: scale(1.1);
 }
 
@@ -100,7 +101,7 @@
 .question-text {
   font-size: 1.1rem;
   line-height: 1.6;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 1.5rem;
 }
 
@@ -114,43 +115,44 @@
   display: flex;
   align-items: flex-start;
   padding: 1rem;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--border-color);
   border-radius: 8px;
-  background: white;
+  background: var(--card-bg);
+  color: var(--text-primary);
   cursor: pointer;
   text-align: left;
   transition: all 0.2s ease;
 }
 
 .answer-button:hover:not(:disabled) {
-  border-color: #4a90d9;
-  background-color: #f5f9ff;
+  border-color: var(--button-primary);
+  background-color: var(--bg-primary);
 }
 
 .answer-button.selected {
-  border-color: #4a90d9;
-  background-color: #e8f0fe;
+  border-color: var(--button-primary);
+  background-color: var(--bg-secondary);
 }
 
 .answer-button.correct {
-  border-color: #28a745;
-  background-color: #d4edda;
+  border-color: var(--correct-text);
+  background-color: var(--correct-bg);
 }
 
 .answer-button.incorrect {
-  border-color: #dc3545;
-  background-color: #f8d7da;
+  border-color: var(--incorrect-text);
+  background-color: var(--incorrect-bg);
 }
 
 .answer-letter {
   font-weight: 700;
-  color: #555;
+  color: var(--text-secondary);
   margin-right: 0.75rem;
   min-width: 24px;
 }
 
 .answer-text {
-  color: #333;
+  color: var(--text-primary);
   line-height: 1.4;
 }
 
@@ -161,24 +163,25 @@
   text-align: center;
   font-weight: 600;
   font-size: 1.1rem;
+  transition: all 0.3s ease;
 }
 
 .result-indicator.correct {
-  background-color: #d4edda;
-  color: #155724;
+  background-color: var(--correct-bg);
+  color: var(--correct-text);
 }
 
 .result-indicator.incorrect {
-  background-color: #f8d7da;
-  color: #721c24;
+  background-color: var(--incorrect-bg);
+  color: var(--incorrect-text);
 }
 
 .must-click-hint {
-  color: #dc3545;
+  color: var(--incorrect-text);
   font-weight: 600;
   text-align: center;
   margin-top: 1rem;
   padding: 0.75rem;
-  background-color: #fff5f5;
+  background-color: var(--incorrect-bg);
   border-radius: 6px;
 }

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS = {
   quickExam: false,
   fontSize: 'medium',
   showAnswer: false,
+  darkMode: false,
   ttsEnabled: false,
   ttsSpeed: 1.0,
   ttsVoice: '',
@@ -83,6 +84,10 @@ export function SettingsProvider({ children }) {
     setSettings(prev => ({ ...prev, showAnswer: value }))
   }
 
+  const setDarkMode = (value) => {
+    setSettings(prev => ({ ...prev, darkMode: value }))
+  }
+
   const setTtsEnabled = (value) => {
     setSettings(prev => ({ ...prev, ttsEnabled: value }))
   }
@@ -132,6 +137,7 @@ export function SettingsProvider({ children }) {
       setQuickExam,
       setFontSize,
       setShowAnswer,
+      setDarkMode,
       setTtsEnabled,
       setTtsSpeed,
       setTtsVoice,

--- a/src/index.css
+++ b/src/index.css
@@ -6,13 +6,49 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #333;
-  background-color: #f5f5f5;
+  
+  /* Light theme (default) */
+  --bg-primary: #f5f5f5;
+  --bg-secondary: #ffffff;
+  --text-primary: #333333;
+  --text-secondary: #666666;
+  --card-bg: #ffffff;
+  --border-color: #e0e0e0;
+  --button-primary: #4a90d9;
+  --button-hover: #357abd;
+  --correct-bg: #d4edda;
+  --correct-text: #155724;
+  --incorrect-bg: #f8d7da;
+  --incorrect-text: #721c24;
+  --shadow: rgba(0, 0, 0, 0.1);
+  --input-bg: #ffffff;
+  --link-color: #4a90d9;
+}
+
+[data-theme='dark'] {
+  --bg-primary: #1a1a2e;
+  --bg-secondary: #16213e;
+  --text-primary: #eaeaea;
+  --text-secondary: #a0a0a0;
+  --card-bg: #0f3460;
+  --border-color: #2a2a4a;
+  --button-primary: #e94560;
+  --button-hover: #d63850;
+  --correct-bg: #1a4d2e;
+  --correct-text: #4ade80;
+  --incorrect-bg: #4d1a1a;
+  --incorrect-text: #f87171;
+  --shadow: rgba(0, 0, 0, 0.3);
+  --input-bg: #1a1a2e;
+  --link-color: #e94560;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 #root {

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -19,13 +19,13 @@
   width: 80px;
   height: auto;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
 }
 
 .home-container h1 {
   font-size: 2.5rem;
   margin: 0;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .button-container {
@@ -44,7 +44,7 @@
   text-align: center;
   text-decoration: none;
   color: white;
-  background-color: #4a90d9;
+  background-color: var(--button-primary);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -52,7 +52,7 @@
 }
 
 .home-button:hover {
-  background-color: #357abd;
+  background-color: var(--button-hover);
 }
 
 .home-button:active {
@@ -67,7 +67,7 @@
 
 .progress-section h2 {
   font-size: 1.5rem;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 1rem;
   text-align: center;
 }
@@ -80,36 +80,38 @@
 }
 
 .stat-card {
-  background: white;
+  background: var(--card-bg);
   padding: 1rem;
   border-radius: 8px;
   text-align: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
+  transition: background-color 0.3s ease;
 }
 
 .stat-value {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #4a90d9;
+  color: var(--button-primary);
 }
 
 .stat-label {
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-top: 0.25rem;
 }
 
 .recent-exams h3 {
   font-size: 1.1rem;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 0.75rem;
 }
 
 .exam-list {
-  background: white;
+  background: var(--card-bg);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
+  transition: background-color 0.3s ease;
 }
 
 .exam-item {
@@ -118,7 +120,7 @@
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   align-items: center;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .exam-item:last-child {
@@ -127,11 +129,11 @@
 
 .exam-license {
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .exam-score {
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .exam-result {
@@ -143,17 +145,17 @@
 }
 
 .exam-result.passed {
-  background-color: #d4edda;
-  color: #155724;
+  background-color: var(--correct-bg);
+  color: var(--correct-text);
 }
 
 .exam-result.failed {
-  background-color: #f8d7da;
-  color: #721c24;
+  background-color: var(--incorrect-bg);
+  color: var(--incorrect-text);
 }
 
 .exam-date {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--text-secondary);
   text-align: right;
 }

--- a/src/pages/Practice.css
+++ b/src/pages/Practice.css
@@ -9,12 +9,12 @@
 .page-container h1 {
   font-size: 2rem;
   margin-bottom: 0.5rem;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .page-description {
   font-size: 1rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 2rem;
   text-align: center;
   max-width: 500px;

--- a/src/pages/Settings.css
+++ b/src/pages/Settings.css
@@ -10,12 +10,12 @@
 .page-container h1 {
   font-size: 2rem;
   margin-bottom: 1rem;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .page-container p {
   font-size: 1.2rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 2rem;
 }
 
@@ -43,23 +43,24 @@
 }
 
 .settings-section {
-  background: white;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
   width: 100%;
+  transition: background-color 0.3s ease;
 }
 
 .settings-section h2 {
   font-size: 1.25rem;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 0.75rem;
 }
 
 .settings-description {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 1.5rem;
 }
 
@@ -77,7 +78,7 @@
 
 .question-input-group label {
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
   min-width: 100px;
 }
 
@@ -92,16 +93,17 @@
   height: 40px;
   font-size: 1rem;
   font-weight: 600;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--border-color);
   border-radius: 6px;
-  background: white;
+  background: var(--card-bg);
+  color: var(--text-primary);
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .control-btn:hover:not(:disabled) {
-  border-color: #4a90d9;
-  background-color: #f5f9ff;
+  border-color: var(--button-primary);
+  background-color: var(--bg-primary);
 }
 
 .control-btn:disabled {
@@ -114,11 +116,11 @@
   text-align: center;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .question-input-group .max-questions {
-  color: #888;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 
@@ -127,7 +129,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 0;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .toggle-group:last-of-type {
@@ -142,12 +144,12 @@
 
 .toggle-label span:first-child {
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .toggle-description {
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .toggle-switch {
@@ -188,7 +190,7 @@
 }
 
 .toggle-switch input:checked + .toggle-slider {
-  background-color: #4a90d9;
+  background-color: var(--button-primary);
 }
 
 .toggle-switch input:checked + .toggle-slider:before {
@@ -200,7 +202,7 @@
   font-size: 1rem;
   font-weight: 600;
   color: #dc3545;
-  background-color: white;
+  background-color: var(--card-bg);
   border: 2px solid #dc3545;
   border-radius: 6px;
   cursor: pointer;
@@ -215,21 +217,22 @@
 .font-size-select {
   padding: 0.5rem 1rem;
   font-size: 1rem;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--border-color);
   border-radius: 6px;
-  background-color: white;
+  background-color: var(--input-bg);
+  color: var(--text-primary);
   cursor: pointer;
   min-width: 150px;
 }
 
 .font-size-select:focus {
   outline: none;
-  border-color: #4a90d9;
+  border-color: var(--button-primary);
 }
 
 .build-number {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--text-secondary);
   margin-top: -0.5rem;
   margin-bottom: 1.5rem;
 }
@@ -238,9 +241,10 @@
 .listening-select {
   padding: 0.5rem 1rem;
   font-size: 1rem;
-  border: 2px solid #e0e0e0;
+  border: 2px solid var(--border-color);
   border-radius: 6px;
-  background-color: white;
+  background-color: var(--input-bg);
+  color: var(--text-primary);
   cursor: pointer;
   min-width: 200px;
 }
@@ -248,14 +252,14 @@
 .voice-select:focus,
 .listening-select:focus {
   outline: none;
-  border-color: #4a90d9;
+  border-color: var(--button-primary);
 }
 
 .speed-slider {
   width: 150px;
   height: 8px;
   border-radius: 4px;
-  background: #ddd;
+  background: var(--border-color);
   outline: none;
   -webkit-appearance: none;
 }
@@ -265,6 +269,6 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #4a90d9;
+  background: var(--button-primary);
   cursor: pointer;
 }

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -11,7 +11,7 @@ const LICENSE_NAMES = {
 }
 
 function Settings() {
-  const { settings, updateStudyQuestions, setQuickPractice, setQuickExam, setFontSize, setShowAnswer, setTtsEnabled, setTtsSpeed, setTtsVoice, setTtsAutoRead, setListeningMode, clearExamHistory, resetToDefaults, MAX_QUESTIONS, FONT_SIZES, buildNumber } = useSettings()
+  const { settings, updateStudyQuestions, setQuickPractice, setQuickExam, setFontSize, setShowAnswer, setDarkMode, setTtsEnabled, setTtsSpeed, setTtsVoice, setTtsAutoRead, setListeningMode, clearExamHistory, resetToDefaults, MAX_QUESTIONS, FONT_SIZES, buildNumber } = useSettings()
   const [voices, setVoices] = useState([])
   const [voicesLoaded, setVoicesLoaded] = useState(false)
 
@@ -154,6 +154,21 @@ function Settings() {
               type="checkbox"
               checked={settings.showAnswer}
               onChange={(e) => setShowAnswer(e.target.checked)}
+            />
+            <span className="toggle-slider"></span>
+          </label>
+        </div>
+
+        <div className="toggle-group">
+          <label className="toggle-label">
+            <span>Dark Mode</span>
+            <span className="toggle-description">Use dark theme for better low-light viewing</span>
+          </label>
+          <label className="toggle-switch">
+            <input
+              type="checkbox"
+              checked={settings.darkMode}
+              onChange={(e) => setDarkMode(e.target.checked)}
             />
             <span className="toggle-slider"></span>
           </label>

--- a/src/pages/Study.css
+++ b/src/pages/Study.css
@@ -9,12 +9,12 @@
 .page-container h1 {
   font-size: 2rem;
   margin-bottom: 0.5rem;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .page-description {
   font-size: 1rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 2rem;
   text-align: center;
   max-width: 500px;


### PR DESCRIPTION
## Summary
Adds a dark mode theme to improve user experience for studying in low-light conditions.

## Changes
- Add CSS variables for light/dark themes in `index.css`
- Add `darkMode` setting to SettingsContext
- Add dark mode toggle in Settings page (Display Settings section)
- Apply theme via `data-theme` attribute on root element
- Update all component CSS files to use CSS variables
- Smooth 0.3s transition between themes

## Dark Theme Colors
- Background: #1a1a2e (primary), #16213e (secondary)
- Text: #eaeaea (primary), #a0a0a0 (secondary)
- Card: #0f3460
- Accent: #e94560 (pink/red)

## Testing
- Test all pages in dark mode
- Verify text readability and contrast
- Test toggle in Settings

Closes #7