### PR TITLE
Fix GitHub Actions deployment permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -52,6 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
 
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -67,8 +77,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          path: ./build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions deployment permission error that was preventing deployment to GitHub Pages.

## Changes
- Add top-level permissions for contents, pages, and id-token
- Switch from peaceiris/actions-gh-pages to actions/deploy-pages@v4
- Use actions/upload-pages-artifact and actions/configure-pages

## Error Fixed
```
remote: Permission to nerdito/HamStudy.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/nerdito/HamStudy.git/': The requested URL returned error: 403
```