### PR TITLE
Feature: Daily Study Streaks (closes #9)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Home from './pages/Home'
 import Study from './pages/Study'
 import Practice from './pages/Practice'
 import Settings from './pages/Settings'
+import Stats from './pages/Stats'
 import { useSettings } from './context/SettingsContext'
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
         <Route path="/study" element={<Study />} />
         <Route path="/practice" element={<Practice />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="/stats" element={<Stats />} />
       </Routes>
     </div>
   )

--- a/src/components/ExamResults.jsx
+++ b/src/components/ExamResults.jsx
@@ -3,7 +3,7 @@ import { useSettings } from '../context/SettingsContext'
 import './ExamResults.css'
 
 function ExamResults({ correct, total, questions, answers, license, onRestart }) {
-  const { saveExamResult } = useSettings()
+  const { saveExamResult, updateStreak } = useSettings()
   const [showIncorrect, setShowIncorrect] = useState(false)
   const percentage = Math.round((correct / total) * 100)
   const wrongCount = total - correct
@@ -11,8 +11,9 @@ function ExamResults({ correct, total, questions, answers, license, onRestart })
   useEffect(() => {
     if (license) {
       saveExamResult({ license, correct, total })
+      updateStreak()
     }
-  }, [license, correct, total, saveExamResult])
+  }, [license, correct, total, saveExamResult, updateStreak])
 
   const getIncorrectQuestions = () => {
     return questions

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -40,6 +40,11 @@ export function SettingsProvider({ children }) {
     return saved ? JSON.parse(saved) : []
   })
 
+  const [streakData, setStreakData] = useState(() => {
+    const saved = localStorage.getItem('hamStudyStreak')
+    return saved ? JSON.parse(saved) : { currentStreak: 0, longestStreak: 0, lastStudyDate: null, totalStudyDays: 0 }
+  })
+
   const [buildNumber] = useState(BUILD_NUMBER || '')
 
   useEffect(() => {
@@ -49,6 +54,59 @@ export function SettingsProvider({ children }) {
   useEffect(() => {
     localStorage.setItem('hamStudyExamHistory', JSON.stringify(examHistory))
   }, [examHistory])
+
+  useEffect(() => {
+    localStorage.setItem('hamStudyStreak', JSON.stringify(streakData))
+  }, [streakData])
+
+  const getTodayString = () => {
+    return new Date().toISOString().split('T')[0]
+  }
+
+  const getYesterdayString = () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    return yesterday.toISOString().split('T')[0]
+  }
+
+  const updateStreak = () => {
+    const today = getTodayString()
+    const yesterday = getYesterdayString()
+
+    setStreakData(prev => {
+      if (prev.lastStudyDate === today) {
+        return prev
+      }
+
+      let newStreak
+      if (prev.lastStudyDate === yesterday) {
+        newStreak = prev.currentStreak + 1
+      } else if (prev.lastStudyDate === null) {
+        newStreak = 1
+      } else {
+        newStreak = 1
+      }
+
+      return {
+        currentStreak: newStreak,
+        longestStreak: Math.max(prev.longestStreak, newStreak),
+        lastStudyDate: today,
+        totalStudyDays: prev.lastStudyDate === today ? prev.totalStudyDays : prev.totalStudyDays + 1
+      }
+    })
+  }
+
+  const getMilestone = (streak) => {
+    const milestones = [
+      { days: 365, name: 'Year Legend', icon: '🏆' },
+      { days: 100, name: 'Century Champion', icon: '🏆' },
+      { days: 60, name: 'Two Month Titan', icon: '🏆' },
+      { days: 30, name: 'Monthly Master', icon: '🏆' },
+      { days: 14, name: 'Two Week Champion', icon: '🏆' },
+      { days: 7, name: 'Week Warrior', icon: '🏆' }
+    ]
+    return milestones.find(m => streak >= m.days) || null
+  }
 
   const updateStudyQuestions = (license, count) => {
     const max = MAX_QUESTIONS[license]
@@ -109,6 +167,9 @@ export function SettingsProvider({ children }) {
       setShowAnswer,
       saveExamResult,
       examHistory,
+      streakData,
+      updateStreak,
+      getMilestone,
       clearExamHistory,
       resetToDefaults,
       MAX_QUESTIONS,

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -19,7 +19,44 @@
   width: 80px;
   height: auto;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.streak-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 2rem;
+  background: linear-gradient(135deg, #ff6b35 0%, #f7931e 100%);
+  border-radius: 50px;
+  color: white;
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 15px rgba(255, 107, 53, 0.4);
+  animation: streak-pulse 2s ease-in-out infinite;
+}
+
+@keyframes streak-pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
+}
+
+.streak-icon {
+  font-size: 1.5rem;
+}
+
+.streak-count {
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.streak-milestone {
+  font-size: 1.5rem;
+  margin-left: 0.25rem;
 }
 
 .home-container h1 {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,7 +10,7 @@ const LICENSE_NAMES = {
 }
 
 function Home() {
-  const { examHistory } = useSettings()
+  const { examHistory, streakData, getMilestone } = useSettings()
 
   const recentExams = examHistory.slice(0, 5)
   
@@ -19,6 +19,8 @@ function Home() {
     averageScore: Math.round(examHistory.reduce((sum, e) => sum + e.percentage, 0) / examHistory.length),
     passRate: Math.round((examHistory.filter(e => e.passed).length / examHistory.length) * 100)
   } : null
+
+  const milestone = getMilestone(streakData.currentStreak)
 
   const formatDate = (dateString) => {
     const date = new Date(dateString)
@@ -37,6 +39,14 @@ function Home() {
         <Link to="/settings" className="home-button">Settings</Link>
       </div>
 
+      {streakData.currentStreak > 0 && (
+        <div className="streak-banner">
+          <span className="streak-icon">🔥</span>
+          <span className="streak-count">{streakData.currentStreak} day{streakData.currentStreak !== 1 ? 's' : ''} streak!</span>
+          {milestone && <span className="streak-milestone">{milestone.icon}</span>}
+        </div>
+      )}
+
       {examHistory.length > 0 && (
         <div className="progress-section">
           <h2>Your Progress</h2>
@@ -54,6 +64,10 @@ function Home() {
               <div className="stat-card">
                 <div className="stat-value">{stats.passRate}%</div>
                 <div className="stat-label">Pass Rate</div>
+              </div>
+              <div className="stat-card">
+                <Link to="/stats" className="stats-link">View All</Link>
+                <div className="stat-label">Detailed Stats</div>
               </div>
             </div>
           )}

--- a/src/pages/Stats.css
+++ b/src/pages/Stats.css
@@ -1,0 +1,156 @@
+.stats-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.stats-page h1 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  color: var(--text-primary);
+}
+
+.no-data {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  text-align: center;
+  padding: 2rem;
+}
+
+.stats-section {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.stats-section h2 {
+  font-size: 1.25rem;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+}
+
+.stats-section h3 {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+  margin-top: 1rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.streak-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.streak-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  background: var(--bg-primary);
+  border-radius: 12px;
+  text-align: center;
+}
+
+.streak-card-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.streak-card-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--button-primary);
+}
+
+.streak-card-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+.current-milestone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, #ff6b35 0%, #f7931e 100%);
+  border-radius: 12px;
+  color: white;
+  margin-bottom: 1rem;
+}
+
+.milestone-icon {
+  font-size: 2rem;
+}
+
+.milestone-text {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.milestones-list {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.milestones-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.milestone-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--bg-primary);
+  border-radius: 8px;
+  text-align: center;
+  opacity: 0.4;
+}
+
+.milestone-badge.earned {
+  opacity: 1;
+  background: linear-gradient(135deg, #ffd700 0%, #ffb700 100%);
+}
+
+.milestone-badge-icon {
+  font-size: 1.5rem;
+}
+
+.milestone-badge-days {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.milestone-badge-name {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 600px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  .streak-stats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .milestones-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -1,0 +1,111 @@
+import { Link } from 'react-router-dom'
+import { useSettings } from '../context/SettingsContext'
+import './Stats.css'
+
+const LICENSE_NAMES = {
+  technician: 'Technician',
+  general: 'General',
+  extra: 'Extra'
+}
+
+function Stats() {
+  const { examHistory, streakData, getMilestone } = useSettings()
+
+  const stats = examHistory.length > 0 ? {
+    totalExams: examHistory.length,
+    averageScore: Math.round(examHistory.reduce((sum, e) => sum + e.percentage, 0) / examHistory.length),
+    passRate: Math.round((examHistory.filter(e => e.passed).length / examHistory.length) * 100)
+  } : null
+
+  const milestone = getMilestone(streakData.currentStreak)
+  const milestones = [
+    { days: 7, name: 'Week Warrior', icon: '🏆' },
+    { days: 14, name: 'Two Week Champion', icon: '🏆' },
+    { days: 30, name: 'Monthly Master', icon: '🏆' },
+    { days: 60, name: 'Two Month Titan', icon: '🏆' },
+    { days: 100, name: 'Century Champion', icon: '🏆' },
+    { days: 365, name: 'Year Legend', icon: '🏆' }
+  ]
+
+  if (examHistory.length === 0) {
+    return (
+      <div className="page-container stats-page">
+        <h1>Statistics</h1>
+        <p className="no-data">No exam history yet. Complete some exams to see your statistics!</p>
+        <Link to="/" className="back-button">Back to Home</Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="page-container stats-page">
+      <h1>Statistics</h1>
+
+      <div className="stats-section">
+        <h2>Streaks</h2>
+        <div className="streak-stats">
+          <div className="streak-card">
+            <span className="streak-card-icon">🔥</span>
+            <span className="streak-card-value">{streakData.currentStreak}</span>
+            <span className="streak-card-label">Current Streak</span>
+          </div>
+          <div className="streak-card">
+            <span className="streak-card-icon">⭐</span>
+            <span className="streak-card-value">{streakData.longestStreak}</span>
+            <span className="streak-card-label">Longest Streak</span>
+          </div>
+          <div className="streak-card">
+            <span className="streak-card-icon">📅</span>
+            <span className="streak-card-value">{streakData.totalStudyDays}</span>
+            <span className="streak-card-label">Total Study Days</span>
+          </div>
+        </div>
+
+        {milestone && (
+          <div className="current-milestone">
+            <span className="milestone-icon">{milestone.icon}</span>
+            <span className="milestone-text">Current: {milestone.name}</span>
+          </div>
+        )}
+
+        <div className="milestones-list">
+          <h3>Milestones</h3>
+          <div className="milestones-grid">
+            {milestones.map(m => (
+              <div 
+                key={m.days} 
+                className={`milestone-badge ${streakData.longestStreak >= m.days ? 'earned' : ''}`}
+              >
+                <span className="milestone-badge-icon">{m.icon}</span>
+                <span className="milestone-badge-days">{m.days} days</span>
+                <span className="milestone-badge-name">{m.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="stats-section">
+        <h2>Overview</h2>
+        <div className="stats-grid">
+          <div className="stat-card">
+            <div className="stat-value">{stats?.totalExams}</div>
+            <div className="stat-label">Total Exams</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats?.averageScore}%</div>
+            <div className="stat-label">Average Score</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{stats?.passRate}%</div>
+            <div className="stat-label">Pass Rate</div>
+          </div>
+        </div>
+      </div>
+
+      <Link to="/" className="back-button">Back to Home</Link>
+    </div>
+  )
+}
+
+export default Stats


### PR DESCRIPTION
## Summary
Adds gamification with daily study streaks to encourage consistent practice.

## Changes
- Add streak data storage and functions to SettingsContext
- Track: currentStreak, longestStreak, lastStudyDate, totalStudyDays
- Implement streak logic: increment on consecutive days, reset if missed
- Add milestone system: 7, 14, 30, 60, 100, 365 days
- Display streak banner on Home page with flame icon
- Add Stats page with streak details and milestone badges
- Wire up streak update when exam is completed

## Features
- Flame icon on home page showing current streak
- Streak automatically increments when you study on consecutive days
- Milestones:
  - 🏆 7 days - Week Warrior
  - 🏆 14 days - Two Week Champion
  - 🏆 30 days - Monthly Master
  - 🏆 60 days - Two Month Titan
  - 🏆 100 days - Century Champion
  - 🏆 365 days - Year Legend
- Stats page shows detailed streak information

## URL
- View stats at `/stats`

Closes #9