### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -51,6 +56,13 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -67,8 +79,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          path: ./build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Fixes GitHub Pages deployment to work with modern GitHub Actions.

## Changes
- Add top-level permissions (contents, pages, id-token)
- Add environment: github-pages to deploy job
- Replace peaceiris action with actions/deploy-pages@v4
- Use actions/upload-pages-artifact and actions/configure-pages

## Manual Setup Required
Before merging, create a GitHub Pages environment:
1. Go to Repository Settings → Environments
2. Create new environment named `github-pages`
3. Save (no other configuration needed)

## Error Fixed
```
HttpError: Missing environment. Ensure your workflow's deployment job has an environment.
```