### PR TITLE
Remove dark mode toggle (now covered by color scheme)

### DIFF
--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -14,7 +14,6 @@ const DEFAULT_SETTINGS = {
   fontSize: 'medium',
   colorScheme: 'light',
   showAnswer: false,
-  darkMode: false,
   ttsEnabled: false,
   ttsSpeed: 1.0,
   ttsVoice: '',

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -159,8 +159,8 @@ function Settings() {
 
         <div className="toggle-group">
           <label className="toggle-label">
-            <span>Dark Mode</span>
-            <span className="toggle-description">Use dark theme for better low-light viewing</span>
+            <span>Show Answer</span>
+            <span className="toggle-description">Show correct answer after answering in Study mode</span>
           </label>
           <label className="toggle-switch">
             <input


### PR DESCRIPTION
## Summary
- Removed standalone Dark Mode toggle from Settings (it was redundant)
- Color Scheme dropdown now includes Dark as one of the options
- Removed unused `darkMode` from DEFAULT_SETTINGS
- Moved Show Answer toggle to Display Settings section

The Dark option is already available in the Color Scheme dropdown alongside Light, Blue, Green, and Purple.